### PR TITLE
Shift

### DIFF
--- a/lib/decrypted_message.txt
+++ b/lib/decrypted_message.txt
@@ -1,0 +1,4 @@
+"hello world"
+"what's up"
+"ok"
+"good morning"

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -1,15 +1,28 @@
-file = File.open('lib/#{ARGV[0]}', "r")
-enigma = Enigma.new
-enigma.encrypt(message, key, date)
-key =
+require './shift'
+require './enigma'
 
-date = ARGV[2]
+shift = Shift.new
+enigma = Enigma.new(shift)
 
-enigma.encrypt(message, key, date)
+file = File.open("#{ARGV[0]}", "r").each do |line|
+  require "pry"; binding.pry
+  File.open("encrypted.txt", "a+").each do |x|
 
-new_file = File.new('lib/#{ARGV[1]}', "w")
-f.write(response)
+    # x << [enigma.encrypt(message, key, date)]
+  end
+end
 
-response = gets.chomp
 
-puts "Created #{file.path} with the key #{} and date #{}"
+#
+#
+#
+# date = ARGV[2]
+#
+# enigma.encrypt(message, key, date)
+#
+# new_file = File.new('lib/#{ARGV[1]}', "w")
+# f.write(response)
+#
+# response = gets.chomp
+#
+# puts "Created #{file.path} with the key #{} and date #{}"

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,13 +1,15 @@
 class Enigma
 
-  def initialize
+  def initialize(shift)
+    @shift = shift
   end
 
-  def encrypt(message, key, date)
+  def encrypt(message,  = key, = date)
+
     # create a hash
   end
 
-  def decrypt
+  def decrypt(message, key, date)
     # create a hash
   end
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -71,18 +71,7 @@ class Shift < Key
         counter(shifts_by_name["A"], key[1])
       end
     end
-    require "pry"; binding.pry
     shifted_ords
   end
 
-  def char_shift_by
-    # require "pry"; binding.pry
-    ordinal_values.rotate(shifts_by_name["A"])
-  end
-  #
-  # def add_ords_to_shifts
-  #   x = ordinal_values("hello world")
-  #   require "pry"; binding.pry
-  #   # this is how you rotate ordinal values
-  # end
 end

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -4,6 +4,12 @@ require './lib/key'
 class Shift < Key
   include Datable
 
+  attr_reader :message
+
+  def write(message)
+    @message = message
+  end
+
   def shifts
     zips = []
     keys_to_integers.zip(offsets) do |key|
@@ -29,7 +35,12 @@ class Shift < Key
     ords
   end
 
-  def shift
+  def char_shift_by
+    x = ordinal_values(message)
+    # require "pry"; binding.pry
+  end
+
+  def add_ords_to_shifts
     x = ordinal_values("hello world")
     require "pry"; binding.pry
     # this is how you rotate ordinal values

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -1,5 +1,5 @@
-require './datable'
-require './key'
+require './lib/datable'
+require './lib/key'
 
 class Shift < Key
   include Datable
@@ -30,9 +30,21 @@ class Shift < Key
   def ordinal_values
     ords = []
       @message.chars.map do |char|
+        if char.ord != 32
         ords << char.downcase.ord
+      else
+        ords << char = " "
+      end
     end
     ords
+  end
+
+  def ords_by_index
+    by_index = Hash.new
+    ordinal_values.each_with_index do |ord, index|
+      by_index[index] = ord
+    end
+    by_index
   end
 
   def counter(shift, ordinal)
@@ -45,17 +57,11 @@ class Shift < Key
     ordinal
   end
 
-  def ords_by_index
-    by_index = Hash.new
-    ordinal_values.each_with_index do |ord, index|
-      by_index[index] = ord
-    end
-    by_index
-  end
-
   def parse_index
     shifted_ords = ords_by_index.map do |key|
-      if key[0] % 4 == 3
+      if key[1] == " "
+        key[1] = " "
+      elsif key[0] % 4 == 3
         counter(shifts_by_name["D"], key[1])
       elsif key[0] % 4 == 2
         counter(shifts_by_name["C"], key[1])
@@ -65,6 +71,7 @@ class Shift < Key
         counter(shifts_by_name["A"], key[1])
       end
     end
+    require "pry"; binding.pry
     shifted_ords
   end
 

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -44,9 +44,18 @@ class Shift < Key
   end
 
   def parse_index
-    ords_by_index.each do |key, ord|
-    require "pry"; binding.pry
+    shifted_ords = ords_by_index.map do |key|
+      if key[0] % 4 == 3
+        shifts_by_name["D"] + key[1]
+      elsif key[0] % 4 == 2
+        shifts_by_name["C"] + key[1]
+      elsif key[0] % 4 == 1
+        shifts_by_name["B"] + key[1]
+      else
+        shifts_by_name["A"] + key[1]
+      end
     end
+    shifted_ords
   end
 
   # def char_shift_by

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -27,9 +27,9 @@ class Shift < Key
     end
   end
 
-  def ordinal_values(message)
+  def ordinal_values
     ords = []
-      message.chars.map do |char|
+      @message.chars.map do |char|
         ords << char.downcase.ord
     end
     ords

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -1,5 +1,5 @@
-require './lib/datable'
-require './lib/key'
+require './datable'
+require './key'
 
 class Shift < Key
   include Datable
@@ -35,6 +35,16 @@ class Shift < Key
     ords
   end
 
+  def counter(shift, ordinal)
+    counter_value = shift
+    until counter_value == 0
+      ordinal += 1
+      ordinal = 97 if ordinal == 123
+      counter_value -= 1
+    end
+    ordinal
+  end
+
   def ords_by_index
     by_index = Hash.new
     ordinal_values.each_with_index do |ord, index|
@@ -46,21 +56,22 @@ class Shift < Key
   def parse_index
     shifted_ords = ords_by_index.map do |key|
       if key[0] % 4 == 3
-        shifts_by_name["D"] + key[1]
+        counter(shifts_by_name["D"], key[1])
       elsif key[0] % 4 == 2
-        shifts_by_name["C"] + key[1]
+        counter(shifts_by_name["C"], key[1])
       elsif key[0] % 4 == 1
-        shifts_by_name["B"] + key[1]
+        counter(shifts_by_name["B"], key[1])
       else
-        shifts_by_name["A"] + key[1]
+        counter(shifts_by_name["A"], key[1])
       end
     end
     shifted_ords
   end
 
-  # def char_shift_by
-  #   ordinal_values.rotate(shifts_by_name["A"])
-  # end
+  def char_shift_by
+    # require "pry"; binding.pry
+    ordinal_values.rotate(shifts_by_name["A"])
+  end
   #
   # def add_ords_to_shifts
   #   x = ordinal_values("hello world")

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -35,9 +35,16 @@ class Shift < Key
     ords
   end
 
+  def ords_by_index
+    by_index = Hash.new
+    ordinal_values.each_with_index do |ord, index|
+      by_index[index] = ord
+    end
+    by_index
+  end
+
   def char_shift_by
-    x = ordinal_values(message)
-    # require "pry"; binding.pry
+    ordinal_values.rotate(shifts_by_name["A"])
   end
 
   def add_ords_to_shifts

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -43,13 +43,19 @@ class Shift < Key
     by_index
   end
 
-  def char_shift_by
-    ordinal_values.rotate(shifts_by_name["A"])
+  def parse_index
+    ords_by_index.each do |key, ord|
+    require "pry"; binding.pry
+    end
   end
 
-  def add_ords_to_shifts
-    x = ordinal_values("hello world")
-    require "pry"; binding.pry
-    # this is how you rotate ordinal values
-  end
+  # def char_shift_by
+  #   ordinal_values.rotate(shifts_by_name["A"])
+  # end
+  #
+  # def add_ords_to_shifts
+  #   x = ordinal_values("hello world")
+  #   require "pry"; binding.pry
+  #   # this is how you rotate ordinal values
+  # end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -1,32 +1,7 @@
 require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/enigma'
-require 'date'
 
 class EnigmaTest < Minitest::Test
-  def test_it_exists
-    enigma = Enigma.new({message: "hello world", key: "02715", date: "040895"})
 
-    assert_instance_of Enigma, enigma
-  end
-
-  def test_it_has_attributes
-    enigma = Enigma.new({message: "hello world", key: "02715", date: "040895"})
-
-    assert_equal "hello world", enigma.message
-    assert_equal "02715", enigma.key
-    assert_equal "040895", enigma.date
-  end
-
-  def test_date_can_take_no_argument
-    enigma = Enigma.new({message: "hello world", key: "02715"})
-
-    assert_equal Date.today.to_s, enigma.date
-  end
-
-  def test_key_can_take_no_argument
-    enigma = Enigma.new({message: "hello world"})
-
-    assert_instance_of String, enigma.key
-  end
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -71,13 +71,13 @@ class ShiftTest < Minitest::Test
   end
 
   def test_add_ords_to_shifts
-    skip
     shift = Shift.new
 
     shift.write("hello world")
     shift.random_number_generator
 
     assert_instance_of Array, shift.char_shift_by
+    assert_equal 0, shift.counter(76)
     # assert_equal 0, shift.add_ords_to_shifts.count
   end
 

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -51,14 +51,24 @@ class ShiftTest < Minitest::Test
     assert_equal true, shift.ordinal_values.include?(32)
   end
 
+  def test_ords_by_index
+    shift = Shift.new
+
+    shift.write("hello world")
+    shift.random_number_generator
+
+    assert_instance_of Hash, shift.ords_by_index
+
+  end
+
   def test_add_ords_to_shifts
     skip
     shift = Shift.new
 
     shift.write("hello world")
+    shift.random_number_generator
 
-    assert_instance_of Array, shift.ordinal_values
-    assert_instance_of Array shift.char_shift_by
+    assert_instance_of Array, shift.char_shift_by
     # assert_equal 0, shift.add_ords_to_shifts.count
   end
 

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -48,7 +48,7 @@ class ShiftTest < Minitest::Test
     shift.write("hello world")
 
     assert_instance_of Array, shift.ordinal_values
-    assert_equal true, shift.ordinal_values.include?(32)
+    assert_equal false, shift.ordinal_values.include?(32)
   end
 
   def test_ords_by_index
@@ -70,15 +70,15 @@ class ShiftTest < Minitest::Test
     assert_instance_of Array, shift.parse_index
   end
 
-  def test_add_ords_to_shifts
+  def test_add_counter_that_resets_to_parse_indexes
     shift = Shift.new
 
     shift.write("hello world")
     shift.random_number_generator
 
-    assert_instance_of Array, shift.char_shift_by
-    assert_equal 0, shift.counter(76)
-    # assert_equal 0, shift.add_ords_to_shifts.count
+    assert_equal 118, shift.counter(8, 110)
+    assert_equal 97, shift.counter(5, 118)
+    assert_equal 122, shift.counter(5, 117)
   end
 
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -41,4 +41,21 @@ class ShiftTest < Minitest::Test
     assert_equal true, shift.ordinal_values("hello world").include?(32)
   end
 
+  def test_it_has_a_message
+    shift = Shift.new
+
+    shift.write("hello world")
+
+    assert_equal "hello world", shift.message
+  end
+
+  def test_add_ords_to_shifts
+    skip
+    shift = Shift.new
+
+    assert_instance_of Array, shift.ordinal_values("hello world")
+    assert_instance_of Array shift.char_shift_by
+    # assert_equal 0, shift.add_ords_to_shifts.count
+  end
+
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -16,7 +16,7 @@ class ShiftTest < Minitest::Test
     assert_equal Time.now.strftime("%d%m%y"), shift.today
   end
 
-  def test_it_can_offset
+  def test_it_can_assign_offset
     shift = Shift.new
 
     assert_equal (shift.today.to_i ** 2), shift.date_squared
@@ -24,7 +24,7 @@ class ShiftTest < Minitest::Test
     assert_equal 4, shift.offsets.count
   end
 
-  def test_it_can_shift
+  def test_it_can_assign_shifts
     shift = Shift.new
 
     shift.random_number_generator
@@ -32,13 +32,6 @@ class ShiftTest < Minitest::Test
     assert_instance_of Array, shift.shifts
     assert_instance_of Hash, shift.shifts_by_name
     assert_instance_of Integer, shift.shifts_by_name["A"]
-  end
-
-  def test_ordinal_values
-    shift = Shift.new
-
-    assert_instance_of Array, shift.ordinal_values("hello world")
-    assert_equal true, shift.ordinal_values("hello world").include?(32)
   end
 
   def test_it_has_a_message
@@ -49,11 +42,22 @@ class ShiftTest < Minitest::Test
     assert_equal "hello world", shift.message
   end
 
+  def test_ordinal_values
+    shift = Shift.new
+
+    shift.write("hello world")
+
+    assert_instance_of Array, shift.ordinal_values
+    assert_equal true, shift.ordinal_values.include?(32)
+  end
+
   def test_add_ords_to_shifts
     skip
     shift = Shift.new
 
-    assert_instance_of Array, shift.ordinal_values("hello world")
+    shift.write("hello world")
+
+    assert_instance_of Array, shift.ordinal_values
     assert_instance_of Array shift.char_shift_by
     # assert_equal 0, shift.add_ords_to_shifts.count
   end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -67,7 +67,7 @@ class ShiftTest < Minitest::Test
     shift.write("hello world")
     shift.random_number_generator
 
-    assert_instance_of Hash, shift.parse_index
+    assert_instance_of Array, shift.parse_index
   end
 
   def test_add_ords_to_shifts

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -58,7 +58,16 @@ class ShiftTest < Minitest::Test
     shift.random_number_generator
 
     assert_instance_of Hash, shift.ords_by_index
+    assert_equal shift.ordinal_values.count, shift.ords_by_index.count
+  end
 
+  def test_parse_out_index_ords
+    shift = Shift.new
+
+    shift.write("hello world")
+    shift.random_number_generator
+
+    assert_instance_of Hash, shift.parse_index
   end
 
   def test_add_ords_to_shifts


### PR DESCRIPTION
Finished most foreseeable reasons to work in `Shift Class`.
- ordinal values translate to ordinals that can be used for converting message to alphabet - see `counter` method, which takes two arguments of `shift` and `ordinal`
- added logic to `parse_index` and `ordinal_values` methods that consider if character is an empty string