### PR TITLE
fix error for argv in crypt#encrypted method

### DIFF
--- a/encrypted.txt
+++ b/encrypted.txt
@@ -1,0 +1,1 @@
+hpcdo ngrwu

--- a/lib/crypt.rb
+++ b/lib/crypt.rb
@@ -14,7 +14,8 @@ class Crypt
 
   def encrypted(created)
     created
-    writer = File.open(ARGV[1], "w")
+    file = ARGV[0]
+    writer = File.open(file, "w")
     writer.write(created)
     writer.close
   end

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -1,4 +1,6 @@
 require './lib/crypt'
 
+arg1 = ARGV[1]
+
 crypt = Crypt.new
 crypt.open_encrypt


### PR DESCRIPTION
- `crypt#encrypted` method knows the encrypted message and the file, but for some reason only knows `ARGV[0]` and not `ARGV[1]` still. This is returning an error when assigning `writer = File.open(ARGV[0], "w")

Next:
- fix this error